### PR TITLE
Display temperature of fluids if not default

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -4,7 +4,7 @@ pressed-fnei-back-key=FNEI back key
 
 [fnei]
 FNEI=FNEI
-recipe-amnt=__1__ × __2__
+recipe-amnt=__1__ × __2__ __3__
 recipe-amnt-range=[__1__ - __2__]
 recipe-amnt-prob=__1__%  __2__
 ingredients=Ingredients

--- a/locale/ru/locale.cfg
+++ b/locale/ru/locale.cfg
@@ -6,7 +6,7 @@ pressed-fnei-back-key=FNEI кнопка назад
 pressed-fnei-gui2-key=FNEI отключенная кнопка
 
 [fnei]
-recipe-amnt=__1__ × __2__
+recipe-amnt=__1__ × __2__ __3__
 recipe-amnt-range=[__1__ - __2__]
 recipe-amnt-prob=__1__%  __2__
 settings-key=настройки

--- a/unsort/recipe_gui.lua
+++ b/unsort/recipe_gui.lua
@@ -341,7 +341,11 @@ function RecipeGui.get_element_caption(element)
 
 
   if element.amount then
-    return {"fnei.recipe-amnt", element.amount, get_localised_name(prot) }
+    if element.type == "fluid" and element.temperature then
+      return {"fnei.recipe-amnt", element.amount, get_localised_name(prot), "(" .. element.temperature .. "°)" }
+    else 
+      return {"fnei.recipe-amnt", element.amount, get_localised_name(prot), "" }
+    end
   else
     local min = element.amount_min or 0
     local max = element.amount_max or 0
@@ -349,7 +353,7 @@ function RecipeGui.get_element_caption(element)
     local ret_val
 
     if not Settings.get_val("detail-chance") then
-      return {"fnei.recipe-amnt", round((min + max) / 2 * prob, 3), get_localised_name(prot)}
+      return {"fnei.recipe-amnt", round((min + max) / 2 * prob, 3), get_localised_name(prot), ""}
     end
 
     if min ~= max then
@@ -358,9 +362,9 @@ function RecipeGui.get_element_caption(element)
       ret_val = max
     end
     if prob == 1 then
-      return {"fnei.recipe-amnt", ret_val, get_localised_name(prot)}
+      return {"fnei.recipe-amnt", ret_val, get_localised_name(prot), ""}
     else
-      return {"fnei.recipe-amnt-prob", {"fnei.recipe-amnt", ret_val, round(prob * 100, 3)}, get_localised_name(prot)}
+      return {"fnei.recipe-amnt-prob", {"fnei.recipe-amnt", ret_val, round(prob * 100, 3), ""}, get_localised_name(prot)}
     end
   end
 end


### PR DESCRIPTION
Hello,

I propose this small change to display the temperature of fluid ingredients or products if it's different from default. This is useful for mod sets such as Pyanodon's that have recipes producing or requiring different temperatures of the same fluid. 

Factorio's own crafting menu shows this information already, although only for ingredients. 