### PR TITLE
Add external interface for locale specific search

### DIFF
--- a/scripts/main/controllers/fnei.lua
+++ b/scripts/main/controllers/fnei.lua
@@ -2,6 +2,8 @@ local FneiMainController = {
   classname = "FNFneiMainController",
 }
 
+local translate = require 'utils/translate'
+
 local pages = "main-pages"
 local cont_gui
 
@@ -28,34 +30,30 @@ function FneiMainController.redraw_content()
 end
 
 function FneiMainController.set_page_list()
-  local page_list = {}
-  local items = get_item_list()
-  local fluid = get_fluid_list()
-
-  for _,item in pairs(items) do
-    table.insert(page_list, "item_" .. item.name)
-  end
-  for _,fluid in pairs(fluid) do
-    table.insert(page_list, "fluid_" .. fluid.name)
-  end
-
-  page_list = FneiMainController.sort_prot(page_list)
-
-  pages.num_per_page = 12 * Settings.get_val("fnei-line-count")
-  pages:set_page_list(page_list)
-end
-
-function FneiMainController.sort_prot(prot_list)
-  local ret_tb = {}
   local search_text = FneiMainController.get_search_field():gsub(" ", "-"):gsub("%p", "%%%0"):lower()
+  local page_list = {}
 
-  for _, prot in pairs(prot_list) do
-    if string.match(prot:lower(), search_text) then
-      table.insert(ret_tb, prot)
+  local items  = get_item_list()
+  local fluids = get_fluid_list()
+
+  for _, item in pairs(items) do
+    local term = translate(item.name, "item") or item.name
+
+    if string.find(term:lower(), search_text) then
+      table.insert(page_list, "item_" .. item.name)
     end
   end
 
-  return ret_tb
+  for _, fluid in pairs(fluids) do
+    local term = translate(fluid.name, "fluid") or fluid.name
+
+    if string.find(term:lower(), search_text) then
+      table.insert(page_list, "fluid_" .. fluid.name)
+    end
+  end
+
+  pages.num_per_page = 12 * Settings.get_val("fnei-line-count")
+  pages:set_page_list(page_list)
 end
 
 function FneiMainController.search_event(event)

--- a/utils/translate.lua
+++ b/utils/translate.lua
@@ -1,0 +1,33 @@
+
+local version  = 1
+local registry = nil
+
+function translate(name, type)
+
+  -- Initialize translator registry in a pluggable way
+  if not registry then
+    registry = {}
+
+    for mod, _ in pairs(remote.interfaces) do
+      if string.find(mod, '^locale%-search') and remote.call(mod, "version") == version then
+        table.insert(registry, mod)
+      end
+    end
+
+    table.sort(registry)
+  end
+
+  -- Ask translator services
+  for _, mod in ipairs(registry) do
+    local value = remote.call(mod, "translate", name, type)
+
+    if value then
+      return value
+    end
+  end
+
+  -- No translation available
+  return nil
+end
+
+return translate


### PR DESCRIPTION
This PR allows users to install mods that expose the interface `locale-search`. This interface allows to translate an item/fluid name in a deterministic fasion, and provide a locale specific name to search against in the FNEI search.

Providing such a plugin is the responsibility of the user. These plugins would be most likely autogenerated by server owners.