### PR TITLE
Desync fix

### DIFF
--- a/utils/recipe_list.lua
+++ b/utils/recipe_list.lua
@@ -4,8 +4,6 @@ local Recipe = {
   classname = "FNRecipe"
 }
 
-local aRecipe
-
 function Recipe:get_recipe_list()
   Debug:debug(Recipe.classname, "get_recipe_list( )")
 
@@ -23,11 +21,7 @@ end
 function Recipe:get_aRecipe_list()
   Debug:debug(Recipe.classname, "get_aRecipe_list( )")
 
-  if not aRecipe then
-    aRecipe = self:create_attainable_recipes()
-  end
-
-  return aRecipe
+  return self:create_attainable_recipes()
 end
 
 --return a list of technologies that can open this recipe_name or {}


### PR DESCRIPTION
Отключил кеширование результата функции Recipe:get_aRecipe_list(), т.к. оно вызывало десинки в мультиплеере при использовании разных force-ов.

Сценарий десинка:
Игрок из форса А заходит на сервер, получает список рецептов для форса А. Список кешируется у него в клиенте и на сервере.
Игрок из форса Б заходит на сервер, получает список рецептов из форса Б. Этот список рецептов у него другой, т.к. исследования в разных форсах идут не одновременно. Но сервер уже закешировал список рецептов для форса А, и поэтому случается десинк.