### PR TITLE
recipe gui: fix caption generation for recipes

### DIFF
--- a/scripts/recipe/gui.lua
+++ b/scripts/recipe/gui.lua
@@ -418,13 +418,21 @@ function RecipeGui.get_element_caption(element)
   end
 
   local ret_val
+  local prob = element.probability or 0
 
   if element.amount then
-    ret_val = {"fnei.recipe-amnt", element.amount, get_localised_name(prot) }
+    if element.probability and prob ~= 1 then
+      if not Settings.get_val("detail-chance") then
+        ret_val = {"fnei.recipe-amnt", round(element.amount * prob, 3), get_localised_name(prot)}
+      else
+        ret_val = {"fnei.recipe-amnt-prob", round(prob * 100, 3), { "fnei.recipe-amnt", element.amount, get_localised_name(prot) } }
+      end
+    else
+      ret_val = {"fnei.recipe-amnt", element.amount, get_localised_name(prot) }
+    end
   else
     local min = element.amount_min or 0
     local max = element.amount_max or 0
-    local prob = element.probability or 0
 
     if not Settings.get_val("detail-chance") then
       ret_val = {"fnei.recipe-amnt", round((min + max) / 2 * prob, 3), get_localised_name(prot)}
@@ -438,7 +446,7 @@ function RecipeGui.get_element_caption(element)
       if prob == 1 then
         ret_val = {"fnei.recipe-amnt", ret_val, get_localised_name(prot)}
       else
-        ret_val = {"fnei.recipe-amnt-prob", {"fnei.recipe-amnt", ret_val, round(prob * 100, 3)}, get_localised_name(prot)}
+        ret_val = {"fnei.recipe-amnt-prob", round(prob * 100, 3), { "fnei.recipe-amnt", ret_val, get_localised_name(prot) } }
       end
     end
   end


### PR DESCRIPTION
- Fix caption generation for recipes which have probability and amount at the same time.
- Change format of probability captions slightly to make them easier to read.