### PR TITLE
Update for 0.18.22 compatibility

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -10,7 +10,7 @@ data:extend({
     type = "custom-input",
     name = "pressed-fnei-gui-key",
     key_sequence = "CONTROL + E",
-    consuming = "script-only"
+    consuming = "game-only"
   }
 })
 
@@ -19,6 +19,6 @@ data:extend({
     type = "custom-input",
     name = "pressed-fnei-back-key",
     key_sequence = "BACKSPACE",
-    consuming = "script-only"
+    consuming = "game-only"
   }
 })


### PR DESCRIPTION
Consuming type of `script-only` was deprecated in 0.15.24 and has been fully removed in current experimental version of 0.18.22